### PR TITLE
add laravel upgrade link

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,7 +69,7 @@
 
     <div class="text-center">
       For upgrade guide see:
-      <a :href="guideLink" target="_blank" class="underline italic">link</a>
+      <a :href="documentationLink" target="_blank" class="underline italic">link</a>
     </div>
 
     <div class="text-center">
@@ -210,13 +210,16 @@
         return 'https://github.com/laravel/laravel/releases/tag/' + this.upgradeVersion;
       },
 
-      guideLink() {
+      documentationLink() {
         if (this.upgradeVersion) {
-          let version = this.upgradeVersion.replace('v', '');
-          version = version[0] >= 6 ? version[0] + '.x' : version.slice(0, 3);
+          const splitVersion = this.upgradeVersion.split('.');
+          const majorVersion = parseInt(splitVersion[0].replace('v', ''));
+          const minorVersion = majorVersion === 5 ? splitVersion[1] : 'x';
 
-          return 'https://laravel.com/docs/' + version + '/upgrade';
+          return `https://laravel.com/docs/${majorVersion}.${minorVersion}/upgrade`;
         }
+
+        return '';
       },
 
       diffFileLink() {

--- a/index.html
+++ b/index.html
@@ -67,7 +67,8 @@
       <a :href="releaseLink" target="_blank" class="underline italic">link</a>
     </div>
 
-    <div class="text-center">
+
+    <div class="text-center" v-show="documentationLink !== ''">
       For upgrade guide see:
       <a :href="documentationLink" target="_blank" class="underline italic">link</a>
     </div>
@@ -212,11 +213,22 @@
 
       documentationLink() {
         if (this.upgradeVersion) {
-          const splitVersion = this.upgradeVersion.split('.');
-          const majorVersion = parseInt(splitVersion[0].replace('v', ''));
-          const minorVersion = majorVersion === 5 ? splitVersion[1] : 'x';
+          const splitUpgradeVersion = this.upgradeVersion.split('.');
+          const upgradeMajorVersion = parseInt(splitUpgradeVersion[0].replace('v', ''));
+          const upgradeMinorVersion = upgradeMajorVersion === 5 ? splitUpgradeVersion[1] : 'x';
 
-          return `https://laravel.com/docs/${majorVersion}.${minorVersion}/upgrade`;
+          const splitBaseVersion = this.baseVersion.split('.');
+          const baseMajorVersion = parseInt(splitBaseVersion[0].replace('v', ''));
+          const baseMinorVersion = baseMajorVersion === 5 ? splitBaseVersion[1] : 'x';
+
+          if (
+            upgradeMajorVersion === baseMajorVersion &&
+            upgradeMinorVersion === baseMinorVersion
+          ) {
+            return '';
+          }
+
+          return `https://laravel.com/docs/${upgradeMajorVersion}.${upgradeMinorVersion}/upgrade`;
         }
 
         return '';

--- a/index.html
+++ b/index.html
@@ -211,10 +211,12 @@
       },
 
       guideLink() {
-        const majorVersion = this.upgradeVersion.split('.').pop();
-        const version = majorVersion >= 6 ? majorVersion + '.x' : this.upgradeVersion.split('.').slice(1, 3).join('.');
+        if (this.upgradeVersion) {
+          let version = this.upgradeVersion.replace('v', '');
+          version = version[0] >= 6 ? version[0] + '.x' : version.slice(0, 3);
 
-        return 'https://laravel.com/docs/' + version + '/upgrade';
+          return 'https://laravel.com/docs/' + version + '/upgrade';
+        }
       },
 
       diffFileLink() {

--- a/index.html
+++ b/index.html
@@ -68,6 +68,11 @@
     </div>
 
     <div class="text-center">
+      For upgrade guide see:
+      <a :href="guideLink" target="_blank" class="underline italic">link</a>
+    </div>
+
+    <div class="text-center">
       Click <a :href="diffFileLink" download><b class="underline text-red">here</b></a>
       to download patch file.
     </div>
@@ -203,6 +208,13 @@
     computed: {
       releaseLink() {
         return 'https://github.com/laravel/laravel/releases/tag/' + this.upgradeVersion;
+      },
+
+      guideLink() {
+        const majorVersion = this.upgradeVersion.split('.').pop();
+        const version = majorVersion >= 6 ? majorVersion + '.x' : this.upgradeVersion.split('.').slice(1, 3).join('.');
+
+        return 'https://laravel.com/docs/' + version + '/upgrade';
       },
 
       diffFileLink() {


### PR DESCRIPTION
With this development, a Laravel upgrade guide link has been added.

If the major version is less than 6, both the major and minor versions are taken into account together.

**Examples:**

- upgrade version = 5.7.15 --> guide link: https://laravel.com/docs/5.7/upgrade
- upgrade version = 8.5.23 --> guide link: https://laravel.com/docs/8.x/upgrade